### PR TITLE
ADD - DEL/places와 reviews 관련 API 추가

### DIFF
--- a/src/controllers/placeController.js
+++ b/src/controllers/placeController.js
@@ -69,9 +69,63 @@ const postAmenityBunches = async(req, res) => {
 };
 
 
+const deletePlaceWithPlaceId = async (req, res) => {
+    try {
+        const { place_id } = req.params;
+    
+        if (!place_id) {
+            return res.status(400).json({message: 'KEY_ERROR'});
+        }
+    
+        await placeService.deletePlaceWithPlaceId(place_id);
+    
+        return res.status(200).json({message: `place with ID ${place_id} is deleted`});
+    } catch (err) {
+        err.statusCode = err.statusCode || 500;
+        res.status(err.statusCode).json({ message: err.message });
+    }
+};
+
+const getReviewsByPlaceId = async (req, res) => {
+    try {
+        const { place_id } = req.params;
+    
+        if (!place_id) {
+            return res.status(400).json({message: 'KEY_ERROR'});
+        }
+    
+        const getReviewsByPlaceId = await placeService.getReviewsByPlaceId(place_id);
+    
+        return res.status(200).json(getReviewsByPlaceId);
+    } catch (err) {
+        err.statusCode = err.statusCode || 500;
+        res.status(err.statusCode).json({ message: err.message });
+    }
+};
+
+const postReviews = async (req, res) => {
+    try {
+        const { booking_id, place_id, rate, comment } = req.body;
+    
+        if (!booking_id || !place_id || !rate || !comment) {
+            return res.status(400).json({message: 'KEY_ERROR'});
+        }
+    
+        await placeService.postReviews(booking_id, place_id, rate, comment);
+    
+        return res.status(200).json({message: "reviewCreated"});
+    } catch (err) {
+        err.statusCode = err.statusCode || 500;
+        res.status(err.statusCode).json({ message: err.message });
+    }
+};
+
 module.exports = {
     getPlaces,
     getPlaceByPlaceId,
     postPlace,
-    postAmenityBunches
+    postAmenityBunches,
+    deletePlaceWithPlaceId,
+    getReviewsByPlaceId,
+    postReviews
 }

--- a/src/models/placeDao.js
+++ b/src/models/placeDao.js
@@ -182,6 +182,44 @@ const getUserTypeId = async (user_id) => {
     return getUserTypeId[0].user_type_id;
 };
 
+const deletePlaceWithPlaceId = async (place_id) => {
+    const deletePlaceWithPlaceId = await appDataSource.query(
+        `DELETE FROM places p
+        WHERE p.id = ${place_id}
+        `);
+
+    return deletePlaceWithPlaceId;
+};
+
+const getReviewsByPlaceId = async (place_id) => {
+    const getReviewsByPlaceId = await appDataSource.query(
+        `SELECT
+            r.rate,
+            r.comment
+        FROM reviews r
+        JOIN places p
+        ON p.id = r.place_id
+        WHERE p.id = ${place_id}
+        `);
+
+        return getReviewsByPlaceId;
+};
+
+const postReviews = async (booking_id, place_id, rate, comment) => {
+    const postReviews = await appDataSource.query(
+        `INSERT INTO reviews(
+            booking_id,
+            place_id,
+            rate,
+            comment
+        ) VALUES (?, ?, ?, ?)
+        `,
+        [booking_id, place_id, rate, comment]
+    );
+
+    return postReviews;
+};
+
 module.exports = {
     getPlaces,
     getPlaceByPlaceId,
@@ -189,5 +227,8 @@ module.exports = {
     postAmenityBunches,
     getPlaceIds,
     hasUserId,
-    getUserTypeId
+    getUserTypeId,
+    deletePlaceWithPlaceId,
+    getReviewsByPlaceId,
+    postReviews
 }

--- a/src/models/reservationDao.js
+++ b/src/models/reservationDao.js
@@ -1,6 +1,5 @@
 const { appDataSource } = require("./datasource");
 
-
 const getReservation = async (userId, placeId, availableFrom, availableUntil, guestNumber, totalPrice) => {
         return await appDataSource.query(
             `

--- a/src/routes/placeRouter.js
+++ b/src/routes/placeRouter.js
@@ -10,6 +10,9 @@ router.get('/:place_id(\\d+)', placeController.getPlaceByPlaceId);
 router.post('/', jwtValidation.validation, placeController.postPlace);
 
 router.post('/amenity_bunches', jwtValidation.validation, placeController.postAmenityBunches);
+router.delete('/:place_id', jwtValidation.validation, placeController.deletePlaceWithPlaceId);
+router.get('/reviews/:place_id', placeController.getReviewsByPlaceId);
+router.post('/review', jwtValidation.validation, placeController.postReviews);
 
 module.exports = {
     router

--- a/src/services/placeService.js
+++ b/src/services/placeService.js
@@ -59,9 +59,47 @@ const postAmenityBunches = async (place_id, amenity_ids) => {
     return postAmenityBunches;
 };
 
+
+const deletePlaceWithPlaceId = async (place_id) => {
+    const getPlaceIds = await placeDao.getPlaceIds();
+
+    if (!getPlaceIds.includes(Number(place_id))) {
+        const err = new Error("PLACE_DOES_NOT_EXIST");
+        err.statusCode = 404;
+        throw err;
+    }
+
+    const deletePlaceWithPlaceId = await placeDao.deletePlaceWithPlaceId(place_id);
+
+    return deletePlaceWithPlaceId;
+};
+
+const getReviewsByPlaceId = async (place_id) => {
+    const getReviewsByPlaceId = await placeDao.getReviewsByPlaceId(place_id);
+
+    return getReviewsByPlaceId;
+};
+
+const postReviews = async (booking_id, place_id, rate, comment) => {
+    const getBookingIds = await placeDao.getBookingIds();
+
+    if (!getBookingIds.includes(booking_id)) {
+        const err = new Error("DID_NOT_BOOK");
+        err.statusCode = 404;
+        throw err;
+    }
+
+    const postReviews = await placeDao.postReviews(booking_id, place_id, rate, comment);
+
+    return postReviews;
+};
+
 module.exports = {
     getPlaces,
     getPlaceByPlaceId,
     postPlace,
-    postAmenityBunches
+    postAmenityBunches,
+    deletePlaceWithPlaceId,
+    getReviewsByPlaceId,
+    postReviews
 }


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)
- [x] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표 (해당 브랜치에서 구현하고자 하는 하나의 목표를 설정합니다.)
- 숙소 정보 제거 기능 추가
- 후기 조회 기능 추가
- 후기 등록 기능 추가

<br />

## :: 구현 사항 설명 (작업한 내용을 상세하게 기록합니다.)
1. 숙소 정보 제거 기능
- 존재하는 숙소 ID로 DELETE request를 보내면 해당 숙소 정보를 삭제
- 숙소 ID가 존재하지 않으면 오류를 반환

2. 후기 조회 기능 
- 후기가 있는 숙소 ID를 request parameter로 GET 요청을 받으면 해당 숙소의 모든 후기를 반환
- 숙소 ID가 잘못됐거나 숙소에 후기가 없으면 빈 배열을 반환

3. 후기 등록 기능
- 예약 ID, 숙소 ID, 평점, 댓글을 request.body에 담은 POST/places/reviews 요청을 보낼 시, 후기를 등록
- 존재하지 않는 예약 ID거나 존재하지 않는 숙소 ID일 때 오류/에러 반환(작업량 대비 시간적 여유가 부족하여 정확한 에러 네이밍은 못 함)

<br />

## :: 성장 포인트 (해당 기능을 구현하며 고민했던 사항이나 새로 알게된 부분, 어려웠던 점 등을 작성합니다.)
- 서비스 단의 조건문을 여러 관점에서 생각해보기 시작.

<br />

## :: 기타 질문 및 특이 사항
- 기획 단계에서 숙소 관련 API가 많음을 인지하고도 혼자 다 맡게 되었습니다. 이유는 배포도 예정되어 있었고 여러명이 같은 파트(숙소)를 맡게되었을 때 conflict를 고치는 과정이 생각보다 훨씬 시간을 많이 소요할 것이라고 생각해서 입니다. 같은 파트를 여러명이 맡게 되었을 때 어떤 식으로 분업이 되고 컨플릭트를 고치는 과정이 어떻게 되는지 궁금합니다.
